### PR TITLE
Replaced deprecated vim.lsp.get_active_clients with vim.lsp.get_clients (fix #8)

### DIFF
--- a/lua/referencer.lua
+++ b/lua/referencer.lua
@@ -103,7 +103,7 @@ function M.update()
         M.delete_all()
 
         local bufnr = vim.api.nvim_get_current_buf()
-        local clients = vim.lsp.get_active_clients({ bufnr = bufnr })
+        local clients = vim.lsp.get_clients({ bufnr = bufnr })
         for _, v in ipairs(clients) do
             M.show_all(v)
         end


### PR DESCRIPTION
vim.lsp.get_active_clients is deprecated and will be removed in Neovim 0.12.